### PR TITLE
mensaje de ayuda y cp PDF a raíz

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ pdf: latex
 
 .PHONY: clean
 clean:
+	rm -f Tutorial-Python_Python-Argentina.pdf
 	rm -rf python-docs-es/venv
 	rm -rf python-docs-es/$(OUTPUT_LATEX)
 	rm -rf python-docs-es/$(OUTPUT_DOCTREE)

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ CPYTHON_DOC            := python-docs-es/cpython/Doc
 help:
 	@echo "Please use 'make <target>' where <target> is one of:"
 	@echo " pdf        Build the PDF for the Tutorial"
+	@echo " clean      Clean folders and make everything ready to run again"
 	@echo ""
 
 
@@ -80,6 +81,7 @@ pdf: latex
 	# FIXME: this should be done via Sphinx properly
 	sed -i -e 's|\\subsubsection\*{Notas al pie}||g' python-docs-es/$(OUTPUT_LATEX)/Tutorial-Python_Python-Argentina.tex
 	cd python-docs-es/$(OUTPUT_LATEX) && make all-pdf
+	cp python-docs-es/$(OUTPUT_LATEX)/Tutorial-Python_Python-Argentina.pdf .
 
 
 .PHONY: clean


### PR DESCRIPTION
Son dos huevadas. ¿A ver qué te parecen?
- Caí tarde en que `make clean` era un comando más así que lo incluyo en el texto de ayuda
- A cada rato me metía en la carpeta `_build/...` así que agregué que haga una copia del PDF final en la carpeta raíz.
